### PR TITLE
Build script improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libserialport"]
 	path = libserialport
-	url = git@github.com:facchinm/libserialport.git
+	url = https://github.com/facchinm/libserialport.git

--- a/compile_arm.sh
+++ b/compile_arm.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -xe
+
+mkdir -p distrib/arm
+cd libserialport
+./autogen.sh
+./configure
+make clean
+make
+cd ..
+gcc main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/  -o listSerialC
+cp listSerialC distrib/arm/listSerialC
+gcc jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I/usr/lib/jvm/java-1.8.0-openjdk-armhf/include/ -I/usr/lib/jvm/java-1.8.0-openjdk-armhf/include/linux/ -shared -fPIC -o liblistSerialsj.so
+cp liblistSerialsj.so distrib/arm/

--- a/compile_linux.sh
+++ b/compile_linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -xe
 
 mkdir -p distrib/linux64
 cd libserialport
@@ -9,7 +9,8 @@ make
 cd ..
 gcc main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/  -o listSerialC
 cp listSerialC distrib/linux64/listSerialC
-gcc jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I/opt/jvm/jdk1.8.0/include/ -I/opt/jvm/jdk1.8.0/include/linux/ -shared -fPIC -o liblistSerialsj.so && cp liblistSerialsj.so distrib/linux64/
+gcc jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I/usr/lib/jvm/java-1.8.0-openjdk-amd64/include/ -I/usr/lib/jvm/java-1.8.0-openjdk-amd64/include/linux/ -shared -fPIC -o liblistSerialsj.so
+cp liblistSerialsj.so distrib/linux64/
 
 mkdir -p distrib/linux32
 cd libserialport
@@ -17,7 +18,8 @@ CFLAGS=-m32 ./configure
 make clean
 make
 cd ..
-gcc -m32 main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/  -o listSerialC
+gcc -m32 main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -o listSerialC
 cp listSerialC distrib/linux32/listSerialC
-gcc -m32 jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I/opt/jvm/jdk1.8.0/include/ -I/opt/jvm/jdk1.8.0/include/linux/ -shared -fPIC -o liblistSerialsj.so && cp liblistSerialsj.so distrib/linux32
+gcc -m32 jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I/usr/lib/jvm/java-1.8.0-openjdk-amd64/include/ -I/usr/lib/jvm/java-1.8.0-openjdk-amd64/include/linux/ -shared -fPIC -o liblistSerialsj.so
+cp liblistSerialsj.so distrib/linux32
 

--- a/compile_linux.sh
+++ b/compile_linux.sh
@@ -2,7 +2,7 @@
 
 mkdir -p distrib/linux64
 cd libserialport
-autoconf
+./autogen.sh
 ./configure
 make clean
 make

--- a/compile_linux.sh
+++ b/compile_linux.sh
@@ -1,6 +1,23 @@
-mkdir -p distrib/linux64 && cd libserialport && ./configure && make clean && make && cd .. && gcc main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/  -o listSerialC && cp listSerialC distrib/linux64/listSerialC
+#!/bin/bash -x
+
+mkdir -p distrib/linux64
+cd libserialport
+autoconf
+./configure
+make clean
+make
+cd ..
+gcc main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/  -o listSerialC
+cp listSerialC distrib/linux64/listSerialC
 gcc jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I/opt/jvm/jdk1.8.0/include/ -I/opt/jvm/jdk1.8.0/include/linux/ -shared -fPIC -o liblistSerialsj.so && cp liblistSerialsj.so distrib/linux64/
 
-mkdir -p distrib/linux32 && cd libserialport && CFLAGS=-m32 ./configure && make clean && make && cd .. && gcc -m32 main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/  -o listSerialC && cp listSerialC distrib/linux32/listSerialC
+mkdir -p distrib/linux32
+cd libserialport
+CFLAGS=-m32 ./configure
+make clean
+make
+cd ..
+gcc -m32 main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/  -o listSerialC
+cp listSerialC distrib/linux32/listSerialC
 gcc -m32 jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I/opt/jvm/jdk1.8.0/include/ -I/opt/jvm/jdk1.8.0/include/linux/ -shared -fPIC -o liblistSerialsj.so && cp liblistSerialsj.so distrib/linux32
 


### PR DESCRIPTION
**This is just a suggestion! Feel free to include single commits.** You might also want to add this information just in the readme (like the java path).

I changed a few things to make the script more flexible. However I have not been able to compile for a 32bit system on x64.

The Java path might also differ. I used this to install java 8 on x64 and also arm:

```
sudo apt-get install openjdk-8-jdk openjdk-8-jre

# arm or x64, might differ on your system
export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-armhf
export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
```

The arm build currently only works on native arm systems, no crosscompiling possible.

Partly fixes a bit of #1 and #3
