### PR TITLE
Add compile_freebsd.sh to compile a native build locally

### DIFF
--- a/compile_freebsd.sh
+++ b/compile_freebsd.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -xe
+
+# REQUIRES: devel/openjdk8 
+JAVA_INCLUDE_PATH=/usr/local/openjdk8/include
+
+# Only compile for native architecture -- no cross-compiling here
+mkdir -p distrib/freebsd
+cd libserialport
+./autogen.sh
+CC=clang ./configure
+make clean
+make
+cd ..
+clang main.c libserialport/freebsd.c libserialport/serialport.c -Ilibserialport/ -lusb -o listSerialC
+cp listSerialC distrib/freebsd/listSerialC
+clang jnilib.c libserialport/freebsd.c libserialport/serialport.c -Ilibserialport/ -I$JAVA_INCLUDE_PATH -I$JAVA_INCLUDE_PATH/freebsd/ -shared -fPIC -o liblistSerialsj.so
+cp liblistSerialsj.so distrib/freebsd/


### PR DESCRIPTION
This addresses #6, allowing this part of the project to be built natively on FreeBSD so that other work may happen to get an up-to-date IDE in the ports tree.
