### PR TITLE
Add AArch64 (ARM 64-bit) build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Prerequisites:
 TLTR:
 ```bash
 dpkg --add-architecture i386
-apt-get install build-essential gcc-multilib g++-multilib mingw-w64 xz-utils libxml2-dev clang patch git gcc-4.8-arm-linux-gnueabihf g++-4.8-arm-linux-gnueabihf autoconf libtool linux-libc-dev:i386 gcc-arm-linux-gnueabihf zip
+apt-get install build-essential gcc-multilib g++-multilib mingw-w64 xz-utils libxml2-dev clang patch git gcc-4.8-arm-linux-gnueabihf g++-4.8-arm-linux-gnueabihf autoconf libtool linux-libc-dev:i386 gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu zip
 #setup osxcross + add binaries to PATH
 git clone https://github.com/facchinm/listSerialPortsC --recursive
 ./pack_and_release.sh

--- a/compile_linux.sh
+++ b/compile_linux.sh
@@ -37,3 +37,15 @@ arm-linux-gnueabihf-gcc main.c libserialport/linux_termios.c libserialport/linux
 cp listSerialC distrib/arm/listSerialC
 arm-linux-gnueabihf-gcc jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I$JAVA_INCLUDE_PATH -I$JAVA_INCLUDE_PATH/linux/ -shared -fPIC -o liblistSerialsj.so
 cp liblistSerialsj.so distrib/arm/
+
+mkdir -p distrib/aarch64
+cd libserialport
+./autogen.sh
+./configure --host=aarch64-linux-gnu
+make clean
+make
+cd ..
+aarch64-linux-gnu-gcc main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/  -o listSerialC
+cp listSerialC distrib/aarch64/listSerialC
+aarch64-linux-gnu-gcc jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I$JAVA_INCLUDE_PATH -I$JAVA_INCLUDE_PATH/linux/ -shared -fPIC -o liblistSerialsj.so
+cp liblistSerialsj.so distrib/aarch64/


### PR DESCRIPTION
This simply adds commands to the end of compile_linux.sh to invoke an
AArch64 cross-compiler to produce a 64-bit ARM build, in the same way as
the existing 32-bit ARM build works.